### PR TITLE
Store Subscription Lift 

### DIFF
--- a/SelmSample/HistoryView.swift
+++ b/SelmSample/HistoryView.swift
@@ -14,19 +14,13 @@ import Selm
 struct HistoryView : View, SelmView {
     @ObservedObject var store: Store<HistoryPage>
     
-    var body: some View {
+    var content: some View {
         VStack(spacing: 20.0) {
             List {
                 ForEach(model.history, id: \.self) { step in
                     Text(step.string)
                 }.onDelete(perform: dispatch • Msg.remove)
             }
-        }
-        .onAppear {
-            self.store.subscribe()
-        }
-        .onDisappear {
-            self.store.unsubscribe()
         }
     }
 }

--- a/SelmSample/SafariPage.swift
+++ b/SelmSample/SafariPage.swift
@@ -24,7 +24,9 @@ struct SafariPage: SelmPageExt {
     enum Msg {
         case dismiss
     }
-    
+
+    private(set) static var onDisappearMsg: Msg? = .dismiss
+
     enum ExternalMsg {
         case noOp
         case dismiss

--- a/SelmSample/SafariView.swift
+++ b/SelmSample/SafariView.swift
@@ -15,11 +15,8 @@ import Selm
 struct SafariView: SelmView {
     @ObservedObject var store: Store<SafariPage>
     
-    var body: some View {
+    var content: some View {
         _SafariView(url: store.model.url)
-            .onDisappear {
-                self.store.dispatch(.dismiss)
-            }
     }
 }
 

--- a/SelmSample/SafariView.swift
+++ b/SelmSample/SafariView.swift
@@ -16,17 +16,18 @@ struct SafariView: SelmView {
     @ObservedObject var store: Store<SafariPage>
     
     var body: some View {
-        _SafariView(store: store).onDisappear {
-            self.store.dispatch(.dismiss)
-        }
+        _SafariView(url: store.model.url)
+            .onDisappear {
+                self.store.dispatch(.dismiss)
+            }
     }
 }
 
-struct _SafariView : UIViewControllerRepresentable, SelmView {
-    @ObservedObject var store: Store<SafariPage>
+struct _SafariView : UIViewControllerRepresentable {
+    var url: URL
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<_SafariView>) -> SFSafariViewController {
-        SFSafariViewController(url: model.url)
+        SFSafariViewController(url: url)
     }
 
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<_SafariView>) {}

--- a/Sources/Selm/Store.swift
+++ b/Sources/Selm/Store.swift
@@ -51,31 +51,11 @@ public class Store<Page>: ObservableObject, Identifiable where Page: _SelmPage {
         }
     }
 
-    public func handleOnAppear() {
-        if Page.subscribesOnAppear {
-            subscribe()
-        }
-
-        if let onAppearMsg = Page.onAppearMsg {
-            dispatch(onAppearMsg)
-        }
-    }
-    
     public func unsubscribe() {
         guard isSubscribing else { return }
-        
+
         runOnQueue {
             self.isSubscribing = false
-        }
-    }
-
-    public func handleOnDisappear() {
-        if Page.unsubscribesOnDisappear {
-            unsubscribe()
-        }
-
-        if let onDisappearMsg = Page.onDisappearMsg {
-            dispatch(onDisappearMsg)
         }
     }
 

--- a/Sources/Selm/Store.swift
+++ b/Sources/Selm/Store.swift
@@ -54,12 +54,32 @@ public class Store<Page>: ObservableObject, Identifiable where Page: _SelmPage {
             self.willChange.send(self.model)
         }
     }
+
+    public func handleOnAppear() {
+        if Page.subscribesOnAppear {
+            subscribe()
+        }
+
+        if let onAppearMsg = Page.onAppearMsg {
+            dispatch(onAppearMsg)
+        }
+    }
     
     public func unsubscribe() {
         guard isSubscribing else { return }
         
         runOnQueue {
             self.isSubscribing = false
+        }
+    }
+
+    public func handleOnDisappear() {
+        if Page.unsubscribesOnDisappear {
+            unsubscribe()
+        }
+
+        if let onDisappearMsg = Page.onDisappearMsg {
+            dispatch(onDisappearMsg)
         }
     }
 

--- a/Sources/Selm/Types.swift
+++ b/Sources/Selm/Types.swift
@@ -18,6 +18,18 @@ public typealias DependsOn3<Item1: Equatable, Item2: Equatable, Item3: Equatable
 public protocol _SelmPage {
     associatedtype Msg
     associatedtype Model
+
+    static var subscribesOnAppear:   Bool { get }
+    static var unsubscribesOnDisappear: Bool { get }
+    static var onAppearMsg:             Msg? { get }
+    static var onDisappearMsg:          Msg? { get }
+}
+
+extension _SelmPage {
+    public static var subscribesOnAppear: Bool { true }
+    public static var unsubscribesOnDisappear: Bool { true }
+    public static var onAppearMsg:    Msg? { .none }
+    public static var onDisappearMsg: Msg? { .none }
 }
 
 @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -57,17 +69,17 @@ extension SelmView {
     public var body: some View {
         return content
             .onAppear {
-                self.store.subscribe()
+                self.store.handleOnAppear()
             }
             .onDisappear {
-                self.store.unsubscribe()
+                self.store.handleOnDisappear()
             }
     }
-    
+
 }
 
 @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension SelmView {
-    public var model: Page.Model { store.model }
+    public var model:    Page.Model { store.model }
     public var dispatch: Dispatch<Page.Msg> { store.dispatch }
 }

--- a/Sources/Selm/Types.swift
+++ b/Sources/Selm/Types.swift
@@ -69,10 +69,22 @@ extension SelmView {
     public var body: some View {
         return content
             .onAppear {
-                self.store.handleOnAppear()
+                if Page.subscribesOnAppear {
+                    self.store.subscribe()
+                }
+
+                if let onAppearMsg = Page.onAppearMsg {
+                    self.store.dispatch(onAppearMsg)
+                }
             }
             .onDisappear {
-                self.store.handleOnDisappear()
+                if Page.unsubscribesOnDisappear {
+                    self.store.unsubscribe()
+                }
+
+                if let onDisappearMsg = Page.onDisappearMsg {
+                    self.store.dispatch(onDisappearMsg)
+                }
             }
     }
 

--- a/Sources/Selm/Types.swift
+++ b/Sources/Selm/Types.swift
@@ -37,8 +37,33 @@ public protocol SelmView: View {
     associatedtype Page: _SelmPage
     associatedtype Msg = Page.Msg
     associatedtype Model = Page.Model
+    associatedtype ViewType: View
 
     var store: Store<Page> { get }
+
+    var content: ViewType { get }
+}
+
+@available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+
+extension SelmView {
+    
+    public var content: some View {
+        // I did this to prevent changing every view right now
+        // In the final implementation, this would be a requiement of conforming to SelmView
+        return Text("Hello, world")
+    }
+    
+    public var body: some View {
+        return content
+            .onAppear {
+                self.store.subscribe()
+            }
+            .onDisappear {
+                self.store.unsubscribe()
+            }
+    }
+    
 }
 
 @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)


### PR DESCRIPTION
**This is still a WIP**

Added a new property to `SelmView` called `content` that will take the place of `body` in a `SelmView`.  

I extended `SelmView` to provide an implementation of `body` that uses this new `content` property, and then subscribes/unsubscribes to the store using the `onAppear` and `onDisappear` modifiers.  

I provided a default implementation of `content` as well, but I think we should remove this in the final implementation if we like this approach.  

There is an issue if you conform to `UIViewControllerRepresentable` like we do in the `_SafariView`. `UIViewControllerRepresentable` provides a default implementation of `body` already that returns `Never`. I fixed by removing `_SafariView` conformance to `SelmView`, but maybe this can be solved by using generic constraints on the extensions of `SelmView`
